### PR TITLE
Update the iDynTree required version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ The **bipedal-locomotion-controllers** project is a _suite_ of libraries for ach
 The **bipedal-locomotion-controllers** project is versatile and it can be used
 to compile only some components. Each component has its own dependencies that
 can be found in [`BipedalLocomotionControllersFindDependencies.cmake`](./cmake/BipedalLocomotionControllersFindDependencies.cmake)
-file. Please note that the indicated version is the the minimum required version.
+file. Please note that the indicated version is the  minimum required version.
 
 - `YarpUtilities` requires:
     - For using it:
-      - [`iDynTree`](https://github.com/robotology/idyntree) (version 0.11.105)
+      - [`iDynTree`](https://github.com/robotology/idyntree) (version 1.0.0)
       - [`YARP`](https://github.com/robotology/YARP)
     - For testing:
       - [`Catch2`](https://github.com/catchorg/Catch2)

--- a/cmake/BipedalLocomotionControllersFindDependencies.cmake
+++ b/cmake/BipedalLocomotionControllersFindDependencies.cmake
@@ -117,7 +117,7 @@ endmacro()
 ################################################################################
 # Find all packages
 
-find_package(iDynTree 0.11.105 QUIET)
+find_package(iDynTree 1.0.0 QUIET)
 checkandset_dependency(iDynTree)
 
 find_package(Catch2 QUIET)


### PR DESCRIPTION
Since the `iDynTree 1.0.0` has been [released](https://github.com/robotology/idyntree/releases/tag/v1.0.0) 
The required minimum version of iDynTree has been updated. This is required by `COMPATIBILITY SameMajorVersion` 
```cmake 
install_basic_package_files(iDynTree VARS_PREFIX ${VARS_PREFIX}
                                     VERSION ${${VARS_PREFIX}_VERSION}
                                     COMPATIBILITY SameMajorVersion
                                     TARGETS_PROPERTY ${VARS_PREFIX}_TARGETS
                                     NO_CHECK_REQUIRED_COMPONENTS_MACRO
                                     ENABLE_COMPATIBILITY_VARS
                                     DEPENDENCIES ${_IDYNTREE_EXPORTED_DEPENDENCIES})
```
In the main iDynTree [`CMakeLists.txt`](https://github.com/robotology/idyntree/blob/516713a5ec71427ee04746243dbc504ead66862f/CMakeLists.txt#L72-L78) file

