### PR TITLE
Fix GitHub Actions CI by removing apt Microsoft repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,13 @@ jobs:
     # DEPENDENCIES
     # ============
 
+    # Remove apt repos that are known to break from time to time 
+    # See https://github.com/actions/virtual-environments/issues/323  
+    - name: Remove broken apt repos [Ubuntu]
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
+
     - name: Dependencies [Windows]
       if: matrix.os == 'windows-latest'
       run: |


### PR DESCRIPTION
This PR fixes GitHub Actions CI by removing apt Microsoft repository.

For further details see:
* https://github.com/robotology/robotology-superbuild/pull/332
* actions/virtual-environments#323