### PR TITLE
Add the possibility to use YarpUtilities::getVectorFromSearchable() with fix sized vectors

### DIFF
--- a/src/YarpUtilities/include/BipedalLocomotionControllers/YarpUtilities/Helper.h
+++ b/src/YarpUtilities/include/BipedalLocomotionControllers/YarpUtilities/Helper.h
@@ -81,6 +81,26 @@ struct has_square_bracket_operator<T, std::void_t<decltype(std::declval<T>()[std
 };
 
 /**
+ * is_resizable is used to build a type-dependent expression that check if an element is \a
+ * resizable (i.e. the element has the methods <code>T::resize()<\code>). This specific
+ * implementation is used when the the object is not \a resizable.
+ */
+template <typename T, typename = void> struct is_resizable : std::false_type
+{
+};
+
+/**
+ * is_resizable is used to build a type-dependent expression that check if an element is \a
+ * resizable (i.e. the element has the methods <code>T::resize()<\code>). This specific
+ * implementation is used when the the object is not \a resizable. Indeed
+ * <code>std::void_t<\endcode> is used to detect ill-formed types in SFINAE context.
+ */
+template <typename T>
+struct is_resizable<T, std::void_t<decltype(std::declval<T>().resize(std::declval<int>()))>> : std::true_type
+{
+};
+
+/**
  * Convert a value in a element of type T
  * @param value the value that will be converted
  * @tparam T return type

--- a/src/YarpUtilities/include/BipedalLocomotionControllers/YarpUtilities/Helper.tpp
+++ b/src/YarpUtilities/include/BipedalLocomotionControllers/YarpUtilities/Helper.tpp
@@ -129,8 +129,21 @@ bool getVectorFromSearchable(const yarp::os::Searchable& config, const std::stri
         return false;
     }
 
-    // resize the vector
-    vector.resize(inputPtr->size());
+    // If the vector can be resize, let resize it. Otherwise it is a fix-size vector and the
+    // dimensions has to be the same of list
+    if constexpr (is_resizable<T>::value)
+        vector.resize(inputPtr->size());
+    else
+    {
+        if (vector.size() != inputPtr->size())
+        {
+            std::cerr << "[BipedalLocomotionControllers::YarpUtilities::getVectorFromSearchable] "
+                         "The size of the vector does not match with the size of the list. List "
+                         "size: "
+                      << inputPtr->size() << ". Vector size: " << vector.size() << std::endl;
+            return false;
+        }
+    }
 
     for (int i = 0; i < inputPtr->size(); i++)
     {


### PR DESCRIPTION
This PR allows calling `getVectorFromSearchable()` with fix sized vectors (i.e. `iDynTree::VectorFixSize`) 

In details, I:
 - introduced `is_resizable` struct: usefull gor checking if a class of type `T` has the method `T::resize()`
- used `if constexpr ()` for checking at compile time if the resize can be performed. If the size is not compatible the method returns an error. 

 Fixes #11 