### PR TITLE
Add the possibility to compile the library as static and shared

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ project(BipedalLocomotionControllers
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
+option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" ON)
+
 option(BUILD_TESTING "Create tests using CMake" OFF)
 include(CTest)
 

--- a/src/YarpUtilities/CMakeLists.txt
+++ b/src/YarpUtilities/CMakeLists.txt
@@ -19,7 +19,7 @@ if(BIPEDAL_LOCOMOTION_CONTROLLERS_COMPILE_YarpUtilities)
     )
 
   # add an executable to the project using the specified source files.
-  add_library(${LIBRARY_TARGET_NAME} SHARED ${YARP_helper_SRC} ${YARP_helper_HDR})
+  add_library(${LIBRARY_TARGET_NAME} ${YARP_helper_SRC} ${YARP_helper_HDR})
 
   target_link_libraries(${LIBRARY_TARGET_NAME} PUBLIC ${YARP_LIBRARIES} ${iDynTree_LIBRARIES})
   add_library(BipedalLocomotionControllers::${LIBRARY_TARGET_NAME} ALIAS ${LIBRARY_TARGET_NAME})

--- a/src/YarpUtilities/include/BipedalLocomotionControllers/YarpUtilities/Helper.tpp
+++ b/src/YarpUtilities/include/BipedalLocomotionControllers/YarpUtilities/Helper.tpp
@@ -161,69 +161,6 @@ bool getVectorFromSearchable(const yarp::os::Searchable& config, const std::stri
     return true;
 }
 
-template <>
-bool getVectorFromSearchable<std::vector<bool>>(const yarp::os::Searchable& config,
-                                                const std::string& key,
-                                                std::vector<bool>& vector)
-{
-
-    static_assert(YARP_UTILITES_CHECK_ELEMENT_SUPPORT(bool),
-                  "[BipedalLocomotionControllers::YarpUtilities::getVectorFromSearchable] The "
-                  "function getElementFromSearchable() cannot be called with the desired "
-                  "element type");
-
-    yarp::os::Value* value;
-    if (!config.check(key, value))
-    {
-        std::cerr << "[BipedalLocomotionControllers::YarpUtilities::getVectorFromSearchable] "
-                     "Missing field "
-                  << key << std::endl;
-        return false;
-    }
-
-    if (value->isNull())
-    {
-        std::cerr << "[BipedalLocomotionControllers::YarpUtilities::getVectorFromSearchable] Empty "
-                     "input value named "
-                  << key << std::endl;
-        return false;
-    }
-
-    if (!value->isList())
-    {
-        std::cerr << "[BipedalLocomotionControllers::YarpUtilities::getVectorFromSearchable] The "
-                     "value named "
-                  << key << "is not associated to a list." << std::endl;
-        return false;
-    }
-
-    yarp::os::Bottle* inputPtr = value->asList();
-    if (inputPtr == nullptr)
-    {
-        std::cerr << "[BipedalLocomotionControllers::YarpUtilities::getVectorFromSearchable] The "
-                     "list associated to the value named "
-                  << key << " is empty." << std::endl;
-        return false;
-    }
-
-    // resize the vector
-    vector.resize(inputPtr->size());
-
-    for (int i = 0; i < inputPtr->size(); i++)
-    {
-        if (!(inputPtr->get(i).isBool()) && !(inputPtr->get(i).isInt()))
-        {
-            std::cerr << "[BipedalLocomotionControllers::YarpUtilities::getVectorFromSearchable] "
-                         "The element of the list associated to the value named "
-                      << key << " is not a boolean ." << std::endl;
-            return false;
-        }
-
-        vector[i] = convertValue<bool>(inputPtr->get(i));
-    }
-    return true;
-}
-
 template <typename T> void mergeSigVector(yarp::sig::Vector& vector, const T& t)
 {
     if constexpr (std::is_arithmetic<T>::value)

--- a/src/YarpUtilities/src/Helper.cpp
+++ b/src/YarpUtilities/src/Helper.cpp
@@ -54,3 +54,60 @@ template <> bool YarpUtilities::convertValue<bool>(const yarp::os::Value& value)
 {
     return value.asBool();
 }
+
+template <>
+bool YarpUtilities::getVectorFromSearchable<std::vector<bool>>(const yarp::os::Searchable& config,
+                                                               const std::string& key,
+                                                               std::vector<bool>& vector)
+{
+    yarp::os::Value* value;
+    if (!config.check(key, value))
+    {
+        std::cerr << "[BipedalLocomotionControllers::YarpUtilities::getVectorFromSearchable] "
+                     "Missing field "
+                  << key << std::endl;
+        return false;
+    }
+
+    if (value->isNull())
+    {
+        std::cerr << "[BipedalLocomotionControllers::YarpUtilities::getVectorFromSearchable] Empty "
+                     "input value named "
+                  << key << std::endl;
+        return false;
+    }
+
+    if (!value->isList())
+    {
+        std::cerr << "[BipedalLocomotionControllers::YarpUtilities::getVectorFromSearchable] The "
+                     "value named "
+                  << key << "is not associated to a list." << std::endl;
+        return false;
+    }
+
+    yarp::os::Bottle* inputPtr = value->asList();
+    if (inputPtr == nullptr)
+    {
+        std::cerr << "[BipedalLocomotionControllers::YarpUtilities::getVectorFromSearchable] The "
+                     "list associated to the value named "
+                  << key << " is empty." << std::endl;
+        return false;
+    }
+
+    // resize the vector
+    vector.resize(inputPtr->size());
+
+    for (int i = 0; i < inputPtr->size(); i++)
+    {
+        if (!(inputPtr->get(i).isBool()) && !(inputPtr->get(i).isInt()))
+        {
+            std::cerr << "[BipedalLocomotionControllers::YarpUtilities::getVectorFromSearchable] "
+                         "The element of the list associated to the value named "
+                      << key << " is not a boolean ." << std::endl;
+            return false;
+        }
+
+        vector[i] = YarpUtilities::convertValue<bool>(inputPtr->get(i));
+    }
+    return true;
+}


### PR DESCRIPTION
Fix the problem presented in  #14. Furthermore, in the main `CMakeLists.txt` I added 
```cmake
option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" ON)
```
See [here](https://github.com/robotology/how-to-export-cpp-library/blob/master/CMakeLists.txt#L98) and [here](https://cmake.org/cmake/help/v3.0/variable/BUILD_SHARED_LIBS.html) for further details