### PR TITLE
Implement isEmpty() method in ParameterHandler library

### DIFF
--- a/src/ParametersHandler/YarpImplementation/include/BipedalLocomotionControllers/ParametersHandler/YarpImplementation.h
+++ b/src/ParametersHandler/YarpImplementation/include/BipedalLocomotionControllers/ParametersHandler/YarpImplementation.h
@@ -84,6 +84,12 @@ public:
     std::string toString() const;
 
     /**
+     * Check if the handler contains parameters
+     * @return true of the the handler does not contains any parameters, false otherwise
+     */
+    bool isEmpty() const;
+
+    /**
      * Destructor
      */
     ~YarpImplementation() = default;

--- a/src/ParametersHandler/YarpImplementation/include/BipedalLocomotionControllers/ParametersHandler/YarpImplementation.h
+++ b/src/ParametersHandler/YarpImplementation/include/BipedalLocomotionControllers/ParametersHandler/YarpImplementation.h
@@ -85,7 +85,7 @@ public:
 
     /**
      * Check if the handler contains parameters
-     * @return true of the the handler does not contains any parameters, false otherwise
+     * @return true if the handler does not contain any parameters, false otherwise
      */
     bool isEmpty() const;
 

--- a/src/ParametersHandler/YarpImplementation/src/YarpImplementation.cpp
+++ b/src/ParametersHandler/YarpImplementation/src/YarpImplementation.cpp
@@ -33,6 +33,6 @@ std::string YarpImplementation::toString() const
 
 bool YarpImplementation::isEmpty() const
 {
-    // if the toString method return an empty string means that the handler is empty
+    // if the toString method returns an empty string means that the handler is empty
     return m_container.toString().empty();
 }

--- a/src/ParametersHandler/YarpImplementation/src/YarpImplementation.cpp
+++ b/src/ParametersHandler/YarpImplementation/src/YarpImplementation.cpp
@@ -30,3 +30,9 @@ std::string YarpImplementation::toString() const
 {
     return m_container.toString();
 }
+
+bool YarpImplementation::isEmpty() const
+{
+    // if the toString method return an empty string means that the handler is empty
+    return m_container.toString().empty();
+}

--- a/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.h
+++ b/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.h
@@ -67,6 +67,14 @@ public:
     std::string toString() const;
 
     /**
+     * Check if the handler contains parameters
+     * @return true of the the handler does not contains any parameters, false otherwise
+     * @warning Please implement the specific version of this method in the Derived class. Please
+     * check YarpImplementation::isEmpty
+     */
+    bool isEmpty() const;
+
+    /**
      * Operator << overloading
      * @param os Output stream objects
      * @param handler reference to the interface

--- a/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.h
+++ b/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.h
@@ -68,7 +68,7 @@ public:
 
     /**
      * Check if the handler contains parameters
-     * @return true of the the handler does not contains any parameters, false otherwise
+     * @return true if the handler does not contain any parameters, false otherwise
      * @warning Please implement the specific version of this method in the Derived class. Please
      * check YarpImplementation::isEmpty
      */

--- a/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.tpp
+++ b/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.tpp
@@ -30,17 +30,21 @@ IParametersHandler<Derived>::getGroup(const std::string& groupName) const
     return static_cast<const Derived*>(this)->getGroup(groupName);
 }
 
-template <class Derived>
-std::string IParametersHandler<Derived>::toString() const
+template <class Derived> std::string IParametersHandler<Derived>::toString() const
 {
     return static_cast<const Derived*>(this)->toString();
 }
 
+template <class Derived> bool IParametersHandler<Derived>::isEmpty() const
+{
+    return static_cast<const Derived*>(this)->isEmpty();
+}
+
 template <class Derived>
-std::ostream& operator<<(std::ostream& os, const IParametersHandler<Derived>&  handler)
+std::ostream& operator<<(std::ostream& os, const IParametersHandler<Derived>& handler)
 {
     return os << handler.toString();
 }
 
 } // namespace ParametersHandler
-} // namespace BipedalLocomotionController
+} // namespace BipedalLocomotionControllers

--- a/src/ParametersHandler/tests/ParametersHandlerTest.cpp
+++ b/src/ParametersHandler/tests/ParametersHandlerTest.cpp
@@ -87,6 +87,11 @@ public:
         return key;
     }
 
+    bool isEmpty() const
+    {
+        return m_map.size() == 0;
+    }
+
     ~BasicImplementation() = default;
 };
 
@@ -134,6 +139,17 @@ TEST_CASE("Get parameters")
         std::vector<std::string> element;
         REQUIRE(groupHandler->getParameter("Donald's nephews", element));
         REQUIRE(element == std::vector<std::string>{"Huey", "Dewey", "Louie"});
+    }
+
+    SECTION("is Empty")
+    {
+        BasicImplementation::unique_ptr groupHandler = parameterHandler->getGroup("CARTOONS");
+        REQUIRE(groupHandler->isEmpty());
+
+        groupHandler->setParameter("Donald's nephews",
+                                   std::vector<std::string>{"Huey", "Dewey", "Louie"});
+
+        REQUIRE_FALSE(groupHandler->isEmpty());
     }
 
     SECTION("Print content")

--- a/src/ParametersHandler/tests/ParametersHandlerYarpTest.cpp
+++ b/src/ParametersHandler/tests/ParametersHandlerYarpTest.cpp
@@ -69,6 +69,16 @@ TEST_CASE("Get parameters")
         REQUIRE(element == donaldsNephews);
     }
 
+    SECTION("is Empty")
+    {
+        YarpImplementation::unique_ptr groupHandler = parameterHandler->getGroup("CARTOONS");
+        REQUIRE(groupHandler->isEmpty());
+
+        groupHandler->setParameter("Donald's nephews", donaldsNephews);
+        REQUIRE_FALSE(groupHandler->isEmpty());
+    }
+
+
     SECTION("Print content")
     {
         std::cout << "Parameters: " << *parameterHandler << std::endl;


### PR DESCRIPTION
The `isEmpty()` method could be really useful to check if the handler contains any parameters.