### PR TITLE
Small refactoring of ParametersHandler

### DIFF
--- a/src/ParametersHandler/YarpImplementation/include/BipedalLocomotionControllers/ParametersHandler/YarpImplementation.h
+++ b/src/ParametersHandler/YarpImplementation/include/BipedalLocomotionControllers/ParametersHandler/YarpImplementation.h
@@ -81,7 +81,7 @@ public:
      * @return A pointer to IParametersHandler, If the group is not found a new empty object is
      * created and returned
      */
-    std::unique_ptr<IParametersHandler<YarpImplementation>> getGroup(const std::string& name) const;
+    unique_ptr getGroup(const std::string& name) const;
 
     /**
      * Return a standard text representation of the content of the object.

--- a/src/ParametersHandler/YarpImplementation/include/BipedalLocomotionControllers/ParametersHandler/YarpImplementation.h
+++ b/src/ParametersHandler/YarpImplementation/include/BipedalLocomotionControllers/ParametersHandler/YarpImplementation.h
@@ -81,8 +81,8 @@ public:
     /**
      * Get a Group from the handler.
      * @param name name of the group
-     * @return A pointer to IParametersHandler, If the group is not found a new empty object is
-     * created and returned
+     * @return A pointer to IParametersHandler, if the group is not found the weak pointer cannot
+     * be locked
      */
     weak_ptr getGroup(const std::string& name) const;
 

--- a/src/ParametersHandler/YarpImplementation/include/BipedalLocomotionControllers/ParametersHandler/YarpImplementation.h
+++ b/src/ParametersHandler/YarpImplementation/include/BipedalLocomotionControllers/ParametersHandler/YarpImplementation.h
@@ -37,7 +37,7 @@ struct is_string : public std::disjunction<std::is_same<char*, typename std::dec
 class YarpImplementation : public IParametersHandler<YarpImplementation>
 {
 
-    yarp::os::Property m_container; /**< Bottle object */
+    yarp::os::Property m_container; /**< Property object */
 
 public:
     /**
@@ -65,9 +65,15 @@ public:
      * @param parameterName name of the parameter
      * @param parameter parameter
      * @tparam T type of the parameter
-     * @return true/false in case of success/failure
      */
     template <typename T> void setParameter(const std::string& parameterName, const T& parameter);
+
+    /**
+     * Set the handler from an object.
+     * @param object The object to copy
+     * @tparam T type of the object
+     */
+    void set(const yarp::os::Searchable& searchable);
 
     /**
      * Get a Group from the handler.

--- a/src/ParametersHandler/YarpImplementation/include/BipedalLocomotionControllers/ParametersHandler/YarpImplementation.h
+++ b/src/ParametersHandler/YarpImplementation/include/BipedalLocomotionControllers/ParametersHandler/YarpImplementation.h
@@ -106,6 +106,11 @@ public:
     bool isEmpty() const;
 
     /**
+     * Clears the handler from all the parameters
+     */
+    void clear();
+
+    /**
      * Destructor
      */
     ~YarpImplementation() = default;

--- a/src/ParametersHandler/YarpImplementation/include/BipedalLocomotionControllers/ParametersHandler/YarpImplementation.h
+++ b/src/ParametersHandler/YarpImplementation/include/BipedalLocomotionControllers/ParametersHandler/YarpImplementation.h
@@ -11,9 +11,11 @@
 // std
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 // YARP
 #include <yarp/os/Searchable.h>
+#include <yarp/os/Bottle.h>
 #include <yarp/os/Property.h>
 
 #include <BipedalLocomotionControllers/ParametersHandler/IParametersHandler.h>
@@ -37,7 +39,8 @@ struct is_string : public std::disjunction<std::is_same<char*, typename std::dec
 class YarpImplementation : public IParametersHandler<YarpImplementation>
 {
 
-    yarp::os::Property m_container; /**< Property object */
+    yarp::os::Bottle m_container; /**< Bottle object */
+    std::unordered_map<std::string, YarpImplementation::shared_ptr> m_lists; /**< Map containing pointers to the (asked) groups */
 
 public:
     /**
@@ -82,6 +85,13 @@ public:
      * created and returned
      */
     weak_ptr getGroup(const std::string& name) const;
+
+    /**
+     * Set a new group on the handler.
+     * @param name name of the group
+     * @param newGroup shared pointer to the new group
+     */
+    void setGroup(const std::string& name, shared_ptr newGroup);
 
     /**
      * Return a standard text representation of the content of the object.

--- a/src/ParametersHandler/YarpImplementation/include/BipedalLocomotionControllers/ParametersHandler/YarpImplementation.h
+++ b/src/ParametersHandler/YarpImplementation/include/BipedalLocomotionControllers/ParametersHandler/YarpImplementation.h
@@ -81,7 +81,7 @@ public:
      * @return A pointer to IParametersHandler, If the group is not found a new empty object is
      * created and returned
      */
-    unique_ptr getGroup(const std::string& name) const;
+    weak_ptr getGroup(const std::string& name) const;
 
     /**
      * Return a standard text representation of the content of the object.

--- a/src/ParametersHandler/YarpImplementation/include/BipedalLocomotionControllers/ParametersHandler/YarpImplementation.tpp
+++ b/src/ParametersHandler/YarpImplementation/include/BipedalLocomotionControllers/ParametersHandler/YarpImplementation.tpp
@@ -17,7 +17,8 @@ namespace ParametersHandler
 template <typename T>
 bool YarpImplementation::getParameter(const std::string& parameterName, T& parameter) const
 {
-    if (m_lists.find(parameterName) != m_lists.end()){ // A list is called with the same name of the parameter we are searching
+    if (m_lists.find(parameterName) != m_lists.end()) // A list is called with the same name of the parameter we are searching
+    { 
         return m_lists.at(parameterName)->getParameter(parameterName, parameter);
     }
     else

--- a/src/ParametersHandler/YarpImplementation/include/BipedalLocomotionControllers/ParametersHandler/YarpImplementation.tpp
+++ b/src/ParametersHandler/YarpImplementation/include/BipedalLocomotionControllers/ParametersHandler/YarpImplementation.tpp
@@ -37,12 +37,21 @@ void YarpImplementation::setParameter(const std::string& parameterName, const T&
     // a scalar element and a strings is retrieved using getElementFromSearchable() function
     if constexpr (std::is_scalar<T>::value || is_string<T>::value)
     {
-        yarp::os::Value newVal;
-        yarp::os::Bottle* list = newVal.asList();
-        list->add(yarp::os::Value(parameterName));
-        list->add(yarp::os::Value(parameter));
-        m_container.add(newVal);
-    } else
+        yarp::os::Value& check = m_container.find(parameterName);
+        if (check.isNull())
+        {
+            yarp::os::Value newVal;
+            yarp::os::Bottle* list = newVal.asList();
+            list->add(yarp::os::Value(parameterName));
+            list->add(yarp::os::Value(parameter));
+            m_container.add(newVal);
+        }
+        else
+        {
+            check = yarp::os::Value(parameter);
+        }
+    }
+    else
     {
         yarp::os::Value yarpValue;
         auto property = yarpValue.asList();

--- a/src/ParametersHandler/YarpImplementation/src/YarpImplementation.cpp
+++ b/src/ParametersHandler/YarpImplementation/src/YarpImplementation.cpp
@@ -21,14 +21,13 @@ void YarpImplementation::set(const yarp::os::Searchable &searchable)
     m_container.fromString(searchable.toString());
 }
 
-std::unique_ptr<IParametersHandler<YarpImplementation>>
-YarpImplementation::getGroup(const std::string& name) const
+YarpImplementation::unique_ptr YarpImplementation::getGroup(const std::string& name) const
 {
     auto& group = m_container.findGroup(name);
     if (group.isNull())
-        return std::make_unique<YarpImplementation>();
+        return YarpImplementation::make_unique();
 
-    return std::make_unique<YarpImplementation>(group);
+    return YarpImplementation::make_unique(group);
 }
 
 std::string YarpImplementation::toString() const

--- a/src/ParametersHandler/YarpImplementation/src/YarpImplementation.cpp
+++ b/src/ParametersHandler/YarpImplementation/src/YarpImplementation.cpp
@@ -16,6 +16,11 @@ YarpImplementation::YarpImplementation(const yarp::os::Searchable& searchable)
     m_container.fromString(searchable.toString());
 }
 
+void YarpImplementation::set(const yarp::os::Searchable &searchable)
+{
+    m_container.fromString(searchable.toString());
+}
+
 std::unique_ptr<IParametersHandler<YarpImplementation>>
 YarpImplementation::getGroup(const std::string& name) const
 {

--- a/src/ParametersHandler/YarpImplementation/src/YarpImplementation.cpp
+++ b/src/ParametersHandler/YarpImplementation/src/YarpImplementation.cpp
@@ -20,8 +20,7 @@ YarpImplementation::YarpImplementation(const yarp::os::Searchable& searchable)
 
 void YarpImplementation::set(const yarp::os::Searchable &searchable)
 {
-    m_container.clear();
-    m_lists.clear();
+    clear();
 
     yarp::os::Bottle bot;
     bot.fromString(searchable.toString());
@@ -86,4 +85,10 @@ bool YarpImplementation::isEmpty() const
 {
     // if the toString method returns an empty string means that the handler is empty
     return ((m_container.size() == 0 || (m_container.size() == 1 && m_container.get(0).isString())) && (m_lists.size() == 0));
+}
+
+void YarpImplementation::clear()
+{
+    m_container.clear();
+    m_lists.clear();
 }

--- a/src/ParametersHandler/YarpImplementation/src/YarpImplementation.cpp
+++ b/src/ParametersHandler/YarpImplementation/src/YarpImplementation.cpp
@@ -13,7 +13,7 @@ using namespace BipedalLocomotionControllers::ParametersHandler;
 
 YarpImplementation::YarpImplementation(const yarp::os::Searchable& searchable)
 {
-    m_container.fromString(searchable.toString());
+    set(searchable);
 }
 
 void YarpImplementation::set(const yarp::os::Searchable &searchable)

--- a/src/ParametersHandler/YarpImplementation/src/YarpImplementation.cpp
+++ b/src/ParametersHandler/YarpImplementation/src/YarpImplementation.cpp
@@ -6,8 +6,10 @@
  */
 
 #include <BipedalLocomotionControllers/ParametersHandler/YarpImplementation.h>
+#include <yarp/os/Bottle.h>
 
 #include <string>
+#include <cassert>
 
 using namespace BipedalLocomotionControllers::ParametersHandler;
 
@@ -18,25 +20,70 @@ YarpImplementation::YarpImplementation(const yarp::os::Searchable& searchable)
 
 void YarpImplementation::set(const yarp::os::Searchable &searchable)
 {
-    m_container.fromString(searchable.toString());
+    m_container.clear();
+    m_lists.clear();
+
+    yarp::os::Bottle bot;
+    bot.fromString(searchable.toString());
+
+    for (size_t i = 0; i < bot.size(); i++) { //all sublists are included in a new object
+        yarp::os::Value& bb = bot.get(i);
+
+        yarp::os::Bottle* sub = bb.asList();
+        if ((sub) && (sub->size() > 1)) {
+            std::string name = sub->get(0).toString();
+            yarp::os::Bottle* subSub = sub->get(1).asList();
+            if ((subSub) && (subSub->size() > 1))
+            {
+                m_lists.emplace(name, make_shared(*subSub));
+            }
+            else
+            {
+                m_container.add(bb);
+            }
+
+        }
+        else
+        {
+            m_container.add(bb);
+        }
+    }
 }
 
 YarpImplementation::weak_ptr YarpImplementation::getGroup(const std::string& name) const
 {
-    auto& group = m_container.findGroup(name);
-    if (group.isNull())
-        return YarpImplementation::make_shared();
+    if (m_lists.find(name) != m_lists.end())
+    {
+        return m_lists.at(name);
+    }
 
-    return YarpImplementation::make_shared(group);
+    return YarpImplementation::make_shared();
+}
+
+void YarpImplementation::setGroup(const std::string &name, IParametersHandler<YarpImplementation>::shared_ptr newGroup)
+{
+    auto downcastedPtr = std::dynamic_pointer_cast<YarpImplementation>(newGroup); //to access m_container
+    assert(downcastedPtr);
+    yarp::os::Bottle backup = downcastedPtr->m_container;
+    yarp::os::Bottle nameAdded;
+    nameAdded.add(yarp::os::Value(name));
+    nameAdded.append(backup);
+    downcastedPtr->m_container = nameAdded; //This is all to add the name at the beginning of the bottle
+    m_lists[name] = newGroup;
 }
 
 std::string YarpImplementation::toString() const
 {
-    return m_container.toString();
+    std::string output = m_container.toString();
+    for (auto& group : m_lists)
+    {
+        output += " (" + group.second->toString() + ")";
+    }
+    return output;
 }
 
 bool YarpImplementation::isEmpty() const
 {
     // if the toString method returns an empty string means that the handler is empty
-    return m_container.toString().empty();
+    return ((m_container.size() == 0 || (m_container.size() == 1 && m_container.get(0).isString())) && (m_lists.size() == 0));
 }

--- a/src/ParametersHandler/YarpImplementation/src/YarpImplementation.cpp
+++ b/src/ParametersHandler/YarpImplementation/src/YarpImplementation.cpp
@@ -25,11 +25,13 @@ void YarpImplementation::set(const yarp::os::Searchable &searchable)
     yarp::os::Bottle bot;
     bot.fromString(searchable.toString());
 
-    for (size_t i = 0; i < bot.size(); i++) { //all sublists are included in a new object
+    for (size_t i = 0; i < bot.size(); i++) //all sublists are included in a new object
+    {
         yarp::os::Value& bb = bot.get(i);
 
         yarp::os::Bottle* sub = bb.asList();
-        if ((sub) && (sub->size() > 1)) {
+        if ((sub) && (sub->size() > 1))
+        {
             std::string name = sub->get(0).toString();
             yarp::os::Bottle* subSub = sub->get(1).asList();
             if ((subSub) && (subSub->size() > 1))
@@ -83,7 +85,9 @@ std::string YarpImplementation::toString() const
 
 bool YarpImplementation::isEmpty() const
 {
-    // if the toString method returns an empty string means that the handler is empty
+    // We check if the container is null and there are no lists. 
+    // A special case is when the container has a single string element. 
+    // This is the case for newly created groups, where the container has only the name of the group itself.
     return ((m_container.size() == 0 || (m_container.size() == 1 && m_container.get(0).isString())) && (m_lists.size() == 0));
 }
 

--- a/src/ParametersHandler/YarpImplementation/src/YarpImplementation.cpp
+++ b/src/ParametersHandler/YarpImplementation/src/YarpImplementation.cpp
@@ -21,13 +21,13 @@ void YarpImplementation::set(const yarp::os::Searchable &searchable)
     m_container.fromString(searchable.toString());
 }
 
-YarpImplementation::unique_ptr YarpImplementation::getGroup(const std::string& name) const
+YarpImplementation::weak_ptr YarpImplementation::getGroup(const std::string& name) const
 {
     auto& group = m_container.findGroup(name);
     if (group.isNull())
-        return YarpImplementation::make_unique();
+        return YarpImplementation::make_shared();
 
-    return YarpImplementation::make_unique(group);
+    return YarpImplementation::make_shared(group);
 }
 
 std::string YarpImplementation::toString() const

--- a/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.h
+++ b/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.h
@@ -25,7 +25,7 @@ template <class Derived> class IParametersHandler
 {
 public:
 
-    using unique_ptr = std::unique_ptr<Derived>;
+    using unique_ptr = std::unique_ptr<IParametersHandler<Derived>>;
 
     /**
      * Get a parameter from the handler.

--- a/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.h
+++ b/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.h
@@ -49,6 +49,15 @@ public:
     template <typename T> void setParameter(const std::string& parameterName, const T& parameter);
 
     /**
+     * Set the handler from an object.
+     * @param object The object to copy
+     * @tparam T type of the object
+     * @warning Please implement the specific version of this method in the Derived class. Please
+     * check YarpImplementation::setParameter
+     */
+    template <typename T> void set(const T& object);
+
+    /**
      * Get a Group from the handler.
      * @param name name of the group
      * @return A pointer to IParametersHandler, If the group is not found the pointer is equal to

--- a/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.h
+++ b/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.h
@@ -25,7 +25,7 @@ template <class Derived> class IParametersHandler
 {
 public:
 
-    using unique_ptr = std::unique_ptr<IParametersHandler<Derived>>;
+    using unique_ptr = std::unique_ptr<Derived>;
 
     /**
      * Get a parameter from the handler.
@@ -65,7 +65,7 @@ public:
      * @warning Please implement the specific version of this method in the Derived class. Please
      * check YarpImplementation::getGroup
      */
-    std::unique_ptr<IParametersHandler<Derived>> getGroup(const std::string& name) const;
+    unique_ptr getGroup(const std::string& name) const;
 
     /**
      * Return a standard text representation of the content of the object.
@@ -97,6 +97,9 @@ public:
      * Destructor
      */
     virtual ~IParametersHandler() = default;
+
+    template<class... Args, typename = typename std::enable_if<std::is_constructible<Derived, Args...>::value>::type>
+    static unique_ptr make_unique(Args&&... args);
 };
 } // namespace ParametersHandler
 } // namespace BipedalLocomotionControllers

--- a/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.h
+++ b/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.h
@@ -27,6 +27,10 @@ public:
 
     using unique_ptr = std::unique_ptr<IParametersHandler<Derived>>;
 
+    using shared_ptr = std::shared_ptr<IParametersHandler<Derived>>;
+
+    using weak_ptr = std::weak_ptr<IParametersHandler<Derived>>;
+
     /**
      * Get a parameter from the handler.
      * @param parameterName name of the parameter
@@ -65,7 +69,7 @@ public:
      * @warning Please implement the specific version of this method in the Derived class. Please
      * check YarpImplementation::getGroup
      */
-    unique_ptr getGroup(const std::string& name) const;
+    weak_ptr getGroup(const std::string& name) const;
 
     /**
      * Return a standard text representation of the content of the object.
@@ -100,6 +104,9 @@ public:
 
     template<class... Args, typename = typename std::enable_if<std::is_constructible<Derived, Args...>::value>::type>
     static unique_ptr make_unique(Args&&... args);
+
+    template<class... Args, typename = typename std::enable_if<std::is_constructible<Derived, Args...>::value>::type>
+    static shared_ptr make_shared(Args&&... args);
 };
 } // namespace ParametersHandler
 } // namespace BipedalLocomotionControllers

--- a/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.h
+++ b/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.h
@@ -64,8 +64,8 @@ public:
     /**
      * Get a Group from the handler.
      * @param name name of the group
-     * @return A pointer to IParametersHandler, If the group is not found the pointer is equal to
-     * nullptr
+     * @return A pointer to IParametersHandler, if the group is not found the weak pointer cannot
+     * be locked
      * @warning Please implement the specific version of this method in the Derived class. Please
      * check YarpImplementation::getGroup
      */

--- a/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.h
+++ b/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.h
@@ -72,6 +72,15 @@ public:
     weak_ptr getGroup(const std::string& name) const;
 
     /**
+     * Set a new group on the handler.
+     * @param name name of the group
+     * @param newGroup shared pointer to the new group
+     * @warning Please implement the specific version of this method in the Derived class. Please
+     * check YarpImplementation::setGroup
+     */
+    void setGroup(const std::string& name, shared_ptr newGroup);
+
+    /**
      * Return a standard text representation of the content of the object.
      * @return a string containing the standard text representation of the content of the object.
      * @warning Please implement the specific version of this method in the Derived class. Please

--- a/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.h
+++ b/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.h
@@ -97,6 +97,13 @@ public:
     bool isEmpty() const;
 
     /**
+     * Clears the handler from all the parameters
+     * @warning Please implement the specific version of this method in the Derived class. Please
+     * check YarpImplementation::clear
+     */
+    void clear();
+
+    /**
      * Operator << overloading
      * @param os Output stream objects
      * @param handler reference to the interface

--- a/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.tpp
+++ b/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.tpp
@@ -24,6 +24,13 @@ void IParametersHandler<Derived>::setParameter(const std::string& parameterName,
 }
 
 template <class Derived>
+template <typename T>
+void IParametersHandler<Derived>::set(const T& object)
+{
+    return static_cast<Derived*>(this)->set(object);
+}
+
+template <class Derived>
 std::unique_ptr<IParametersHandler<Derived>>
 IParametersHandler<Derived>::getGroup(const std::string& groupName) const
 {

--- a/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.tpp
+++ b/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.tpp
@@ -31,7 +31,7 @@ void IParametersHandler<Derived>::set(const T& object)
 }
 
 template <class Derived>
-typename IParametersHandler<Derived>::unique_ptr
+typename IParametersHandler<Derived>::weak_ptr
 IParametersHandler<Derived>::getGroup(const std::string& groupName) const
 {
     return static_cast<const Derived*>(this)->getGroup(groupName);
@@ -58,6 +58,13 @@ template<class... Args, typename>
 typename IParametersHandler<Derived>::unique_ptr IParametersHandler<Derived>::make_unique(Args&&... args)
 {
     return std::make_unique<Derived>(std::forward<Args>(args)...);
+}
+
+template <class Derived>
+template<class... Args, typename>
+typename IParametersHandler<Derived>::shared_ptr IParametersHandler<Derived>::make_shared(Args&&... args)
+{
+    return std::make_shared<Derived>(std::forward<Args>(args)...);
 }
 
 } // namespace ParametersHandler

--- a/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.tpp
+++ b/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.tpp
@@ -53,6 +53,11 @@ template <class Derived> bool IParametersHandler<Derived>::isEmpty() const
     return static_cast<const Derived*>(this)->isEmpty();
 }
 
+template <class Derived> void IParametersHandler<Derived>::clear()
+{
+    return static_cast<Derived*>(this)->clear();
+}
+
 template <class Derived>
 std::ostream& operator<<(std::ostream& os, const IParametersHandler<Derived>& handler)
 {

--- a/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.tpp
+++ b/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.tpp
@@ -31,7 +31,7 @@ void IParametersHandler<Derived>::set(const T& object)
 }
 
 template <class Derived>
-std::unique_ptr<IParametersHandler<Derived>>
+typename IParametersHandler<Derived>::unique_ptr
 IParametersHandler<Derived>::getGroup(const std::string& groupName) const
 {
     return static_cast<const Derived*>(this)->getGroup(groupName);
@@ -51,6 +51,13 @@ template <class Derived>
 std::ostream& operator<<(std::ostream& os, const IParametersHandler<Derived>& handler)
 {
     return os << handler.toString();
+}
+
+template <class Derived>
+template<class... Args, typename>
+typename IParametersHandler<Derived>::unique_ptr IParametersHandler<Derived>::make_unique(Args&&... args)
+{
+    return std::make_unique<Derived>(std::forward<Args>(args)...);
 }
 
 } // namespace ParametersHandler

--- a/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.tpp
+++ b/src/ParametersHandler/include/BipedalLocomotionControllers/ParametersHandler/IParametersHandler.tpp
@@ -37,6 +37,12 @@ IParametersHandler<Derived>::getGroup(const std::string& groupName) const
     return static_cast<const Derived*>(this)->getGroup(groupName);
 }
 
+template <class Derived>
+void IParametersHandler<Derived>::setGroup(const std::string& groupName, IParametersHandler<Derived>::shared_ptr newGroup)
+{
+    static_cast<Derived*>(this)->setGroup(groupName, newGroup);
+}
+
 template <class Derived> std::string IParametersHandler<Derived>::toString() const
 {
     return static_cast<const Derived*>(this)->toString();

--- a/src/ParametersHandler/tests/CMakeLists.txt
+++ b/src/ParametersHandler/tests/CMakeLists.txt
@@ -3,6 +3,9 @@
 # GNU Lesser General Public License v2.1 or any later version.
 
 if(BIPEDAL_LOCOMOTION_CONTROLLERS_COMPILE_tests)
+  include_directories(${CMAKE_CURRENT_BINARY_DIR})
+  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/ConfigFolderPath.h.in" "${CMAKE_CURRENT_BINARY_DIR}/ConfigFolderPath.h" @ONLY)
+
   add_library(ParametersHandlerTestMain ParametersHandlerTestMain.cpp)
   target_link_libraries(ParametersHandlerTestMain PRIVATE Catch2::Catch2)
 

--- a/src/ParametersHandler/tests/ConfigFolderPath.h.in
+++ b/src/ParametersHandler/tests/ConfigFolderPath.h.in
@@ -1,0 +1,18 @@
+/**
+ * @file FolderPath.h(.in)
+ * @authors Stefano Dafarra
+ * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
+ * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef CONFIG_FOLDERPATH_H_IN
+#define CONFIG_FOLDERPATH_H_IN
+
+#define SOURCE_CONFIG_DIR "@CMAKE_CURRENT_SOURCE_DIR@"
+
+inline std::string getConfigPath()
+{
+    return std::string(SOURCE_CONFIG_DIR) + "/config.ini";
+}
+
+#endif // CONFIG_FOLDERPATH_H_IN

--- a/src/ParametersHandler/tests/ParametersHandlerTest.cpp
+++ b/src/ParametersHandler/tests/ParametersHandlerTest.cpp
@@ -58,11 +58,11 @@ public:
         return true;
     }
 
-    std::unique_ptr<IParametersHandler<BasicImplementation>> getGroup(const std::string& name) const
+    BasicImplementation::unique_ptr getGroup(const std::string& name) const
     {
         auto group = m_map.find(name);
         if (group == m_map.end())
-            return std::make_unique<BasicImplementation>();
+            return BasicImplementation::make_unique();
 
         std::unordered_map<std::string, std::any> map;
         try
@@ -72,10 +72,10 @@ public:
         {
             std::cerr << "[BasicImplementation::getGroup] The element named " << name
                       << " is not a 'std::unordered_map<std::string, std::any>'" << std::endl;
-            return std::make_unique<BasicImplementation>();
+            return BasicImplementation::make_unique();
         }
 
-        return std::make_unique<BasicImplementation>(map);
+        return BasicImplementation::make_unique(map);
     }
 
     std::string toString() const
@@ -97,7 +97,7 @@ public:
 
 TEST_CASE("Get parameters")
 {
-    BasicImplementation::unique_ptr parameterHandler = std::make_unique<BasicImplementation>();
+    BasicImplementation::unique_ptr parameterHandler = BasicImplementation::make_unique();
     parameterHandler->setParameter("answer_to_the_ultimate_question_of_life", 42);
     parameterHandler->setParameter("pi", 3.14);
     parameterHandler->setParameter("Fibonacci Numbers", std::vector<int>{1, 1, 2, 3, 5, 8, 13, 21});

--- a/src/ParametersHandler/tests/ParametersHandlerTest.cpp
+++ b/src/ParametersHandler/tests/ParametersHandlerTest.cpp
@@ -78,6 +78,11 @@ public:
         return BasicImplementation::make_unique(map);
     }
 
+    void set(const std::unordered_map<std::string, std::any>& object)
+    {
+        m_map = object;
+    }
+
     std::string toString() const
     {
         std::string key;
@@ -155,5 +160,15 @@ TEST_CASE("Get parameters")
     SECTION("Print content")
     {
         std::cout << "Parameters: " << *parameterHandler << std::endl;
+    }
+
+    SECTION("Set from object")
+    {
+        std::unordered_map<std::string, std::any> object;
+        object["value"] = std::make_any<int>(10);
+        parameterHandler->set(object);
+        int expected;
+        REQUIRE(parameterHandler->getParameter("value", expected));
+        REQUIRE(expected == 10);
     }
 }

--- a/src/ParametersHandler/tests/ParametersHandlerTest.cpp
+++ b/src/ParametersHandler/tests/ParametersHandlerTest.cpp
@@ -58,16 +58,22 @@ public:
         return true;
     }
 
+    void setGroup(const std::string& name, shared_ptr newGroup)
+    {
+        m_map[name] = std::make_any<shared_ptr>(newGroup);
+    }
+
+
     BasicImplementation::weak_ptr getGroup(const std::string& name) const
     {
         auto group = m_map.find(name);
         if (group == m_map.end())
             return BasicImplementation::make_shared();
 
-        std::unordered_map<std::string, std::any> map;
+        shared_ptr map;
         try
         {
-            map = std::any_cast<decltype(map)>(group->second);
+            map = std::any_cast<shared_ptr>(group->second);
         } catch (const std::bad_any_cast& exception)
         {
             std::cerr << "[BasicImplementation::getGroup] The element named " << name
@@ -75,7 +81,7 @@ public:
             return BasicImplementation::make_shared();
         }
 
-        return BasicImplementation::make_shared(map);
+        return map;
     }
 
     void set(const std::unordered_map<std::string, std::any>& object)
@@ -136,8 +142,10 @@ TEST_CASE("Get parameters")
         REQUIRE(element == std::vector<int>{1, 1, 2, 3, 5, 8, 13, 21});
     }
 
-    SECTION("Get Group")
+    SECTION("Set/Get Group")
     {
+        BasicImplementation::shared_ptr newGroup = BasicImplementation::make_shared();
+        parameterHandler->setGroup("CARTOONS", newGroup);
         BasicImplementation::shared_ptr groupHandler = parameterHandler->getGroup("CARTOONS").lock();
         REQUIRE(groupHandler);
         groupHandler->setParameter("Donald's nephews",
@@ -149,6 +157,8 @@ TEST_CASE("Get parameters")
 
     SECTION("is Empty")
     {
+        BasicImplementation::shared_ptr newGroup = BasicImplementation::make_shared();
+        parameterHandler->setGroup("CARTOONS", newGroup);
         BasicImplementation::shared_ptr groupHandler = parameterHandler->getGroup("CARTOONS").lock();
         REQUIRE(groupHandler);
         REQUIRE(groupHandler->isEmpty());

--- a/src/ParametersHandler/tests/ParametersHandlerTest.cpp
+++ b/src/ParametersHandler/tests/ParametersHandlerTest.cpp
@@ -58,11 +58,11 @@ public:
         return true;
     }
 
-    BasicImplementation::unique_ptr getGroup(const std::string& name) const
+    BasicImplementation::weak_ptr getGroup(const std::string& name) const
     {
         auto group = m_map.find(name);
         if (group == m_map.end())
-            return BasicImplementation::make_unique();
+            return BasicImplementation::make_shared();
 
         std::unordered_map<std::string, std::any> map;
         try
@@ -72,10 +72,10 @@ public:
         {
             std::cerr << "[BasicImplementation::getGroup] The element named " << name
                       << " is not a 'std::unordered_map<std::string, std::any>'" << std::endl;
-            return BasicImplementation::make_unique();
+            return BasicImplementation::make_shared();
         }
 
-        return BasicImplementation::make_unique(map);
+        return BasicImplementation::make_shared(map);
     }
 
     void set(const std::unordered_map<std::string, std::any>& object)
@@ -138,7 +138,8 @@ TEST_CASE("Get parameters")
 
     SECTION("Get Group")
     {
-        BasicImplementation::unique_ptr groupHandler = parameterHandler->getGroup("CARTOONS");
+        BasicImplementation::shared_ptr groupHandler = parameterHandler->getGroup("CARTOONS").lock();
+        REQUIRE(groupHandler);
         groupHandler->setParameter("Donald's nephews",
                                    std::vector<std::string>{"Huey", "Dewey", "Louie"});
         std::vector<std::string> element;
@@ -148,7 +149,8 @@ TEST_CASE("Get parameters")
 
     SECTION("is Empty")
     {
-        BasicImplementation::unique_ptr groupHandler = parameterHandler->getGroup("CARTOONS");
+        BasicImplementation::shared_ptr groupHandler = parameterHandler->getGroup("CARTOONS").lock();
+        REQUIRE(groupHandler);
         REQUIRE(groupHandler->isEmpty());
 
         groupHandler->setParameter("Donald's nephews",

--- a/src/ParametersHandler/tests/ParametersHandlerTest.cpp
+++ b/src/ParametersHandler/tests/ParametersHandlerTest.cpp
@@ -103,6 +103,11 @@ public:
         return m_map.size() == 0;
     }
 
+    void clear()
+    {
+        m_map.clear();
+    }
+
     ~BasicImplementation() = default;
 };
 
@@ -182,5 +187,12 @@ TEST_CASE("Get parameters")
         int expected;
         REQUIRE(parameterHandler->getParameter("value", expected));
         REQUIRE(expected == 10);
+    }
+
+    SECTION("Clear")
+    {
+        REQUIRE_FALSE(parameterHandler->isEmpty());
+        parameterHandler->clear();
+        REQUIRE(parameterHandler->isEmpty());
     }
 }

--- a/src/ParametersHandler/tests/ParametersHandlerYarpTest.cpp
+++ b/src/ParametersHandler/tests/ParametersHandlerYarpTest.cpp
@@ -64,7 +64,8 @@ TEST_CASE("Get parameters")
 
     SECTION("Get Group")
     {
-        YarpImplementation::unique_ptr cartoonsGroup = parameterHandler->getGroup("CARTOONS");
+        YarpImplementation::shared_ptr cartoonsGroup = parameterHandler->getGroup("CARTOONS").lock();
+        REQUIRE(cartoonsGroup);
         cartoonsGroup->setParameter("Donald's nephews", donaldsNephews);
         std::vector<std::string> element;
         REQUIRE(cartoonsGroup->getParameter("Donald's nephews", element));
@@ -73,7 +74,8 @@ TEST_CASE("Get parameters")
 
     SECTION("is Empty")
     {
-        YarpImplementation::unique_ptr groupHandler = parameterHandler->getGroup("CARTOONS");
+        YarpImplementation::shared_ptr groupHandler = parameterHandler->getGroup("CARTOONS").lock();
+        REQUIRE(groupHandler);
         REQUIRE(groupHandler->isEmpty());
 
         groupHandler->setParameter("Donald's nephews", donaldsNephews);

--- a/src/ParametersHandler/tests/ParametersHandlerYarpTest.cpp
+++ b/src/ParametersHandler/tests/ParametersHandlerYarpTest.cpp
@@ -28,7 +28,7 @@ TEST_CASE("Get parameters")
     std::vector<int> fibonacciNumbers{1, 1, 2, 3, 5, 8, 13, 21};
     std::vector<std::string> donaldsNephews{"Huey", "Dewey", "Louie"};
 
-    YarpImplementation::unique_ptr parameterHandler = std::make_unique<YarpImplementation>();
+    YarpImplementation::unique_ptr parameterHandler = YarpImplementation::make_unique();
     parameterHandler->setParameter("answer_to_the_ultimate_question_of_life", 42);
     parameterHandler->setParameter("pi", 3.14);
     parameterHandler->setParameter("John", "Smith");

--- a/src/ParametersHandler/tests/ParametersHandlerYarpTest.cpp
+++ b/src/ParametersHandler/tests/ParametersHandlerYarpTest.cpp
@@ -62,41 +62,52 @@ TEST_CASE("Get parameters")
         REQUIRE(element == fibonacciNumbers);
     }
 
-    SECTION("Get Group")
+    SECTION("Set/Get Group")
     {
+        YarpImplementation::shared_ptr setGroup = YarpImplementation::make_shared();
+        setGroup->setParameter("Donald's nephews", donaldsNephews);
+        parameterHandler->setGroup("CARTOONS", setGroup);
         YarpImplementation::shared_ptr cartoonsGroup = parameterHandler->getGroup("CARTOONS").lock();
         REQUIRE(cartoonsGroup);
-        cartoonsGroup->setParameter("Donald's nephews", donaldsNephews);
+
         std::vector<std::string> element;
         REQUIRE(cartoonsGroup->getParameter("Donald's nephews", element));
         REQUIRE(element == donaldsNephews);
     }
-
-    SECTION("is Empty")
-    {
-        YarpImplementation::shared_ptr groupHandler = parameterHandler->getGroup("CARTOONS").lock();
-        REQUIRE(groupHandler);
-        REQUIRE(groupHandler->isEmpty());
-
-        groupHandler->setParameter("Donald's nephews", donaldsNephews);
-        REQUIRE_FALSE(groupHandler->isEmpty());
-    }
-
 
     SECTION("Print content")
     {
         std::cout << "Parameters: " << *parameterHandler << std::endl;
     }
 
+    SECTION("is Empty")
+    {
+        YarpImplementation::shared_ptr groupHandler = parameterHandler->getGroup("CARTOONS").lock();
+        REQUIRE_FALSE(groupHandler);
+        YarpImplementation::shared_ptr setGroup = YarpImplementation::make_shared();
+        parameterHandler->setGroup("CARTOONS", setGroup);
+
+        groupHandler = parameterHandler->getGroup("CARTOONS").lock(); //now the pointer should be lockable
+        REQUIRE(groupHandler);
+        REQUIRE(groupHandler->isEmpty());
+
+        groupHandler->setParameter("Donald's nephews", donaldsNephews);
+        REQUIRE_FALSE(groupHandler->isEmpty());
+        std::cout << "Parameters: " << *parameterHandler << std::endl;
+
+    }
+
     SECTION("Set from object")
     {
         yarp::os::ResourceFinder rf;
         parameterHandler->set(rf);
+
         yarp::os::Property property;
         property.put("value", 10);
         parameterHandler->set(property);
         int expected;
         REQUIRE(parameterHandler->getParameter("value", expected));
         REQUIRE(expected == 10);
+
     }
 }

--- a/src/ParametersHandler/tests/ParametersHandlerYarpTest.cpp
+++ b/src/ParametersHandler/tests/ParametersHandlerYarpTest.cpp
@@ -15,6 +15,8 @@
 #include <yarp/os/Property.h>
 #include <yarp/os/Searchable.h>
 #include <yarp/os/Value.h>
+#include <yarp/os/ResourceFinder.h>
+#include <yarp/os/Bottle.h>
 
 #include <BipedalLocomotionControllers/ParametersHandler/IParametersHandler.h>
 #include <BipedalLocomotionControllers/ParametersHandler/YarpImplementation.h>
@@ -82,5 +84,17 @@ TEST_CASE("Get parameters")
     SECTION("Print content")
     {
         std::cout << "Parameters: " << *parameterHandler << std::endl;
+    }
+
+    SECTION("Set from object")
+    {
+        yarp::os::ResourceFinder rf;
+        parameterHandler->set(rf);
+        yarp::os::Property property;
+        property.put("value", 10);
+        parameterHandler->set(property);
+        int expected;
+        REQUIRE(parameterHandler->getParameter("value", expected));
+        REQUIRE(expected == 10);
     }
 }

--- a/src/ParametersHandler/tests/ParametersHandlerYarpTest.cpp
+++ b/src/ParametersHandler/tests/ParametersHandlerYarpTest.cpp
@@ -57,8 +57,25 @@ TEST_CASE("Get parameters")
         REQUIRE(element == "Smith");
     }
 
+    SECTION("Change String")
+    {
+        parameterHandler->setParameter("John", "Doe");
+        std::string element;
+        REQUIRE(parameterHandler->getParameter("John", element));
+        REQUIRE(element == "Doe");
+    }
+
     SECTION("Get Vector")
     {
+        std::vector<int> element;
+        REQUIRE(parameterHandler->getParameter("Fibonacci Numbers", element));
+        REQUIRE(element == fibonacciNumbers);
+    }
+
+    SECTION("Change Vector")
+    {
+        fibonacciNumbers.push_back(34);
+        parameterHandler->setParameter("Fibonacci Numbers", fibonacciNumbers);
         std::vector<int> element;
         REQUIRE(parameterHandler->getParameter("Fibonacci Numbers", element));
         REQUIRE(element == fibonacciNumbers);

--- a/src/ParametersHandler/tests/ParametersHandlerYarpTest.cpp
+++ b/src/ParametersHandler/tests/ParametersHandlerYarpTest.cpp
@@ -108,6 +108,13 @@ TEST_CASE("Get parameters")
         int expected;
         REQUIRE(parameterHandler->getParameter("value", expected));
         REQUIRE(expected == 10);
-
     }
+
+    SECTION("Clear")
+    {
+        REQUIRE_FALSE(parameterHandler->isEmpty());
+        parameterHandler->clear();
+        REQUIRE(parameterHandler->isEmpty());
+    }
+
 }

--- a/src/ParametersHandler/tests/config.ini
+++ b/src/ParametersHandler/tests/config.ini
@@ -1,0 +1,7 @@
+answer_to_the_ultimate_question_of_life 42
+pi                                      3.14
+John                                    Smith
+"Fibonacci Numbers"                     (1, 1, 2, 3, 5, 8, 13, 21)
+
+[CARTOONS]
+"Donald's nephews"                      ("Huey", "Dewey", "Louie")


### PR DESCRIPTION
Initially, the refactoring started adding utility functions like ``make_unique``, or the possibility to set the handler from another generic object. Then, @GiulioRomualdi realized (https://github.com/dic-iit/bipedal-locomotion-controllers/issues/20) there were issues with the usage of ``unique_ptr`` which caused other issues about ownership and how the groups were handled.

One possibility to fix these issues was to return a ``weak_ptr`` to the group. In this way, it is clear who owns the group and ideally, any parameter modified in the group would have appeared also in the original handler. But then the issue was that the original handler should have held a shared pointer to group. Then, I decided that the handler should also contain a map where I associate the group name to a shared pointer containing the group. But, how to populate this map? And here the complications started. 

The definition of "group" is foggy in ``yarp``. Indeed, any list can be treated as a group. In fact, given its internal representation, the following appeared to be the same:
- ``"joint_list" (torso neck)``
- ``NEW_GROUP (frame torso)``.

The actual discriminant is the user himself, meaning that he only knows which key corresponds to a group and which one to a list. Hence, I thought of populating the group map only after a user request. The user call ``getGroup("gianni")``, then I know that "gianni" is a group, create the shared pointer and move the group from the container to the map. Profit (?). Nope, ``getGroup`` is ``const`` and it absolutely makes sense for it to be so. 

Another idea, populate the map together with the container as soon as the handler is created. Since we cannot know how to distinguish groups from lists, we treat every list as a group. Not so fast. Consider the case we have a list like
```
"joint_list" (torso neck knee)
```
This would have been treated like a group named "joint_list" with a parameter named "torso" whose value is "neck". "knee" is gone. This because internally we use a ``yarp::os::Property`` to store the parameters and it requires every value to have a key. Those elements which don't satisfy this pattern are simply lost.  For this reason, I decided to use directly a ``yarp::os::Bottle`` as a container. 

Finally, every list is stored into a new handler and by using a ``yarp::os::Bottle`` we avoid losing data. Hence, ``"joint_list" (torso neck knee)`` would be stored into a new handler pointed by a shared pointer from the original handler. Now, in order to make sure that ``getParameter("joint_list")`` actually returns our beloved list, we also need to search if any of the pointed lists has the name "joint_list". Since the utilities to get a list out of a ``Searchable`` (like a ``Bottle``) were already in place, I wanted this line to work
```
lists.at(parameterName)->getParameter(parameterName, parameter);
```
This was possible by adding the name of the group into the ``Bottle`` of the group itself. Bonus point, this makes printing easier.

Tl;Dr
All the functionalities we had before are preserved plus:
- there is a specific method (not ``const``) to set a new group
- a group is returned with a ``weak_ptr``
- any modification in the group is reflected in the handler from which we retrieve it
- we can clear the handler 
- we can set the handler also after its creation
- added new test cases, including one with an actual config file.
