### PR TITLE
Fix missing fields when parsing config files

### DIFF
--- a/src/ParametersHandler/YarpImplementation/src/YarpImplementation.cpp
+++ b/src/ParametersHandler/YarpImplementation/src/YarpImplementation.cpp
@@ -36,7 +36,7 @@ void YarpImplementation::set(const yarp::os::Searchable &searchable)
             yarp::os::Bottle* subSub = sub->get(1).asList();
             if ((subSub) && (subSub->size() > 1))
             {
-                m_lists.emplace(name, make_shared(*subSub));
+                m_lists.emplace(name, make_shared(*sub));
             }
             else
             {

--- a/src/ParametersHandler/tests/ParametersHandlerYarpTest.cpp
+++ b/src/ParametersHandler/tests/ParametersHandlerYarpTest.cpp
@@ -174,12 +174,31 @@ TEST_CASE("Get parameters")
         }
 
         {
-            YarpImplementation::shared_ptr cartoonsGroup = parameterHandler->getGroup("CARTOONS").lock();
-            REQUIRE(cartoonsGroup);
+            std::vector<int> element;
+            REQUIRE(parameterHandler->getParameter("Fibonacci Numbers", element));
+            REQUIRE(element == fibonacciNumbers);
+        }
 
+        YarpImplementation::shared_ptr cartoonsGroup = parameterHandler->getGroup("CARTOONS").lock();
+        REQUIRE(cartoonsGroup);
+
+        {
             std::vector<std::string> element;
             REQUIRE(cartoonsGroup->getParameter("Donald's nephews", element));
             REQUIRE(element == donaldsNephews);
+
+        }
+
+        {
+            std::vector<int> element;
+            REQUIRE(cartoonsGroup->getParameter("Fibonacci_Numbers", element));
+            REQUIRE(element == fibonacciNumbers);
+        }
+
+        {
+            std::string element;
+            REQUIRE(cartoonsGroup->getParameter("John", element));
+            REQUIRE(element == "Doe");
         }
     }
 

--- a/src/ParametersHandler/tests/config.ini
+++ b/src/ParametersHandler/tests/config.ini
@@ -5,3 +5,6 @@ John                                    Smith
 
 [CARTOONS]
 "Donald's nephews"                      ("Huey", "Dewey", "Louie")
+Fibonacci_Numbers                       (1, 1, 2, 3, 5, 8, 13, 21)
+John                                    Doe
+


### PR DESCRIPTION
Added test cases.

#18 was broken. Whoops :sweat_smile: 